### PR TITLE
SimpleExampleMapper/JsonColumnParser: parses CQL for AbstractTypes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.2
+version=0.1.3

--- a/sstable-core/src/main/java/com/fullcontact/sstable/util/CQLUtil.java
+++ b/sstable-core/src/main/java/com/fullcontact/sstable/util/CQLUtil.java
@@ -1,0 +1,34 @@
+package com.fullcontact.sstable.util;
+
+import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.CreateColumnFamilyStatement;
+import org.apache.cassandra.db.ColumnFamilyType;
+import org.apache.cassandra.exceptions.RequestValidationException;
+
+/**
+ * Basic utilities, centralizing CQL convenience functions
+ *
+ * @author Michael Rose <michael@fullcontact.com>
+ */
+public class CQLUtil {
+    /**
+     * Parses a CQL CREATE statement into its CFMetaData object
+     *
+     * @param cql
+     * @return CFMetaData
+     * @throws RequestValidationException if CQL is invalid
+     */
+    public static CFMetaData parseCreateStatement(String cql) throws RequestValidationException {
+        final CreateColumnFamilyStatement statement =
+                (CreateColumnFamilyStatement) QueryProcessor.parseStatement(cql).prepare().statement;
+
+        final CFMetaData cfm =
+                new CFMetaData("assess", "kvs_strict", ColumnFamilyType.Standard, statement.comparator, null);
+
+        statement.applyPropertiesTo(cfm);
+        return cfm;
+    }
+
+    private CQLUtil() {}
+}


### PR DESCRIPTION
A little bit more complex, but we've already had a few questions about the key/columntype, especially since the default `AbstractType` is a `CompoundType`. We should really be getting this from the `CFMetaData` since we're already parsing it.
